### PR TITLE
fix: windows support

### DIFF
--- a/docs/WINDOWS_SUPPORT.md
+++ b/docs/WINDOWS_SUPPORT.md
@@ -1,0 +1,183 @@
+# Windows support
+
+Agentic RenderDoc on Windows runs against the standard `qrenderdoc.exe`
+distribution. There are three constraints in that environment that the
+rest of the codebase is shaped around — this doc records them so the
+choices in the source aren't mystery decisions.
+
+## Constraint 1: qrenderdoc embeds Python 3.6
+
+`C:\Program Files\RenderDoc\qrenderdoc.exe` (current RenderDoc 1.44)
+links `python36.dll` statically and exposes `renderdoc` / `qrenderdoc`
+as built-in modules of that interpreter. There is no separate
+`renderdoc.pyd` shipped on disk — those bindings are only reachable
+from inside `qrenderdoc.exe`.
+
+Consequence: every `.py` file under `src/extension/` may be loaded by
+that 3.6.4 interpreter (when the extension auto-loads, when
+`qrenderdoc --script` runs `src/extension/embedded_headless.py`, etc.).
+The source therefore uses only syntax supported by 3.6:
+
+- No `from __future__ import annotations` — PEP 563 is 3.7+.
+- No PEP-585 subscripted built-ins (`list[X]`, `dict[K, V]`, `tuple[...]`,
+  `set[X]`, `type[X]`) — annotation use requires 3.9+. Use
+  `List[X]`, `Dict[K, V]`, etc. from `typing`.
+- No PEP-604 union syntax (`X | None`, `A | B`) in annotations — 3.10+.
+  Use `Optional[X]` / `Union[A, B]` from `typing`.
+- No walrus (`:=`, 3.8), no `match` statement (3.10), no positional-only
+  params via `/` in signatures (3.8).
+
+The `src/server/` half runs in the user's own Python (≥3.10 per
+`pyproject.toml`) and is unconstrained — modern syntax is fine there.
+
+## Constraint 2: qrenderdoc's Python ships without `_socket`
+
+The bundled Python 3.6 has no `_socket` C extension. Any module that
+transitively imports `socket` at module-load time will crash the
+extension during import. The known offenders:
+
+- `socket`                — direct.
+- `multiprocessing`       — imports `socket`.
+- `concurrent.futures`    — imports `multiprocessing`.
+- `asyncio`               — imports `socket`.
+
+`HeadlessHandlerContext` uses `concurrent.futures.Future` and
+`queue.Queue`. Both are imported lazily inside `__init__` rather than
+at module scope; the class itself is only instantiated by the external-
+Python entry point (`src/extension/headless.py`), so the lazy imports
+never fire inside qrenderdoc, and the rest of the package (`bridge`,
+`handlers`, `api_index`, `serialize`, `utilities`, ...) imports
+cleanly under the GUI path.
+
+Where bridge code needs TCP, it goes through `src/extension/winsock.py`,
+which wraps `ws2_32.dll` directly via `ctypes` on Windows and
+delegates to stdlib `socket` on POSIX. The threaded bridge backend
+(`_ThreadedBridge` in `bridge.py`) uses that wrapper; the Qt backend
+uses `QTcpServer` from PySide2 (qrenderdoc bundles PySide2).
+
+## Constraint 3: `AlwaysLoad_Extensions` name-form mismatch
+
+qrenderdoc's `UI.config` has an `AlwaysLoad_Extensions` list that
+auto-loads named extensions at startup. **On Windows, the matching is
+inconsistent between the extension directory name and the
+`extension.json` `name` field.** Empirically, listing only the
+hyphenated JSON name (`agentic-renderdoc`) is silently ignored; only
+when the underscored directory form (`agentic_renderdoc`) is also
+present does auto-load fire.
+
+The recommended setup writes both forms:
+
+```python
+import json, os
+path = os.path.join(os.environ["APPDATA"], "qrenderdoc", "UI.config")
+with open(path, "r", encoding="utf-8") as f:
+    cfg = json.load(f)
+ext_list = cfg.setdefault("AlwaysLoad_Extensions", [])
+for n in ("agentic-renderdoc", "agentic_renderdoc"):
+    if n not in ext_list:
+        ext_list.append(n)
+with open(path, "w", encoding="utf-8") as f:
+    json.dump(cfg, f, indent=4)
+    f.write("\n")
+```
+
+(This is likely a bug or undocumented quirk in qrenderdoc itself,
+not something we can fix from the extension side.)
+
+## `embedded_headless.py` — Windows headless replay
+
+Because RenderDoc on Windows doesn't ship a standalone `renderdoc.pyd`,
+the external-Python headless path (`extension/headless.py`) cannot
+import the bindings and so cannot run. Headless mode on Windows
+instead uses `qrenderdoc.exe --script <embedded_headless.py>`:
+
+- `--script` runs the script *before* qrenderdoc opens its main UI.
+- As long as the script never returns, the UI never opens — confirmed
+  with a 30-second blocking probe.
+- The script opens the capture in-process via `rd.OpenCaptureFile()`
+  / `OpenCapture()`, runs the existing `BridgeServer` from
+  `src/extension/bridge.py` (with `force_threaded=True`, since a Qt
+  event loop would hijack qrenderdoc's), and blocks until the bridge
+  receives a `shutdown` command.
+- On shutdown the script calls `os._exit(0)` — `sys.exit()` would
+  raise `SystemExit`, which qrenderdoc may catch and then proceed
+  to the UI-launch step.
+
+The new code paths are intentionally small:
+
+- `src/extension/embedded_headless.py` — the entry script. ~130 lines.
+  Reads env-var config, sets up `sys.path`, instantiates
+  `EmbeddedHeadlessContext`, starts the existing `BridgeServer`
+  (`force_threaded=True`), blocks on the bridge's `_running` flag,
+  then `os._exit(0)`. Uses the upstream `HANDLERS` from
+  `extension/handlers.py` for `eval` / `instance_info` / `shutdown`
+  etc., so Windows users get the same rich eval namespace
+  (`bind_utilities`, `inspect`, `diff_state`, `goto_event`, …) that
+  Linux gets.
+- `EmbeddedHeadlessContext` in `src/extension/context.py` — sibling
+  of `HeadlessHandlerContext`. Same single-replay-thread discipline,
+  but opens the capture in-process via `rd.OpenCaptureFile()` rather
+  than `CreateRemoteServerConnection()`, and uses `threading.Event`
+  for setup signalling instead of `concurrent.futures.Future`
+  (because `concurrent.futures` transitively imports `socket`, which
+  qrenderdoc's Python lacks — see Constraint 2).
+- The `sys.platform == "win32"` branch in
+  `src/server/client.py`:`spawn_headless_worker`, which launches
+  `qrenderdoc.exe --script embedded_headless.py` with config supplied
+  via env vars (qrenderdoc does not populate `sys.argv` inside
+  `--script`). Env vars used:
+  - `AGENTIC_EMBEDDED_CAPTURE`     — absolute `.rdc` path.
+  - `AGENTIC_EMBEDDED_PORT_MIN/MAX`— bridge port range.
+  - `AGENTIC_EMBEDDED_PKG_PARENT`  — extension package's parent dir,
+    prepended to `sys.path` by the script so it can import from the
+    `extension` package without depending on `__file__`.
+  - `AGENTIC_DISABLE_AUTOLOAD`     — set to `1` so qrenderdoc's
+    `AlwaysLoad_Extensions` doesn't trigger the GUI-context bridge to
+    bind a competing socket on the same port. Without this, on
+    Windows with `SO_REUSEADDR`, two bridges coexist as listeners and
+    incoming connections routinely hit the GUI bridge instead of ours.
+    The extension's `register()` checks this env var and no-ops.
+
+Diagnostics from the embedded script land in
+`%TEMP%/agentic-renderdoc-embedded-<port>.log` (port-suffixed to
+prevent concurrent workers racing on a shared file).
+
+## Summary of changes specifically for Windows support
+
+| File | Change |
+|---|---|
+| `src/extension/__init__.py` | Replaced `from __future__ import annotations` + PEP-604 syntax with `typing.Optional`. |
+| `src/extension/api_index.py` | Same — typing.* in place of PEP-585 subscripted generics. |
+| `src/extension/bridge.py` | Same, plus `SO_REUSEADDR` on the threaded listener (see note below). |
+| `src/extension/context.py` | Same, plus lazy `import concurrent.futures` / `queue` inside `HeadlessHandlerContext.__init__` so importing the module doesn't pull `concurrent.futures` (which transitively requires `socket`). Plus a new `EmbeddedHeadlessContext` class for in-process replay inside qrenderdoc. |
+| `src/extension/handlers.py` | Same. `collections.abc.Callable` → `typing.Callable` (subscripted `Callable[[...], ...]` annotations require `typing.Callable` on 3.6). |
+| `src/extension/serialize.py` | Syntax-only. |
+| `src/extension/utilities.py` | Same as handlers.py. |
+| `src/extension/headless.py` | Syntax-only. Runs in external Python only, but kept consistent. |
+| `src/extension/renderdoc_locate.py` | Syntax-only. |
+| `src/extension/winsock.py` | Single type-comment fix for a 3.6-incompatible annotation in the Windows branch. |
+| `src/extension/embedded_headless.py` | **New.** Thin Windows headless entry point (~130 lines). Imports `EmbeddedHeadlessContext`, `BridgeServer`, and the upstream `HANDLERS` from the package — no logic duplicated. |
+| `src/server/client.py` | Windows branch in `spawn_headless_worker` to launch `qrenderdoc --script embedded_headless.py`. `_find_qrenderdoc()` helper. Bind-failure error message reads `%TEMP%/agentic-renderdoc-embedded-<port>.log` when the embedded path failed (qrenderdoc as GUI doesn't surface stderr). Skips the `renderdoccmd remote-server` port allocation on Windows since the embedded path doesn't use one. |
+
+Linux Python 3.10+ is unaffected — all replaced syntax is valid in
+every Python ≥3.5, and the Windows-specific branches in `client.py`
+are guarded by `sys.platform == "win32"`.
+
+## Side note: `SO_REUSEADDR` on the threaded bridge
+
+`_ThreadedBridge.start()` in `src/extension/bridge.py` now calls
+`setsockopt_reuse()` on the listener socket before `bind()`. This is a
+cross-platform improvement, not Windows-specific:
+
+- On any platform, the MCP server's port-discovery probe in
+  `src/server/client.py:_first_free_port` binds a port with
+  `SO_REUSEADDR` and closes it immediately before spawning the worker.
+  Without `SO_REUSEADDR` on the worker's listener, the worker can fail
+  to rebind the same port during the brief window the OS holds it.
+- On Linux/macOS, `SO_REUSEADDR` just allows rebinding through TIME_WAIT
+  — standard, safe behaviour.
+- On Windows specifically, `SO_REUSEADDR` has hijacking semantics
+  (multiple listeners can coexist on the same port), which is what
+  makes the `AGENTIC_DISABLE_AUTOLOAD` env var (above) necessary —
+  without it, both the auto-loaded GUI bridge and the embedded bridge
+  would bind the same port and connections would race.

--- a/src/extension/__init__.py
+++ b/src/extension/__init__.py
@@ -3,9 +3,7 @@
 Registers the CaptureViewer and starts the TCP bridge server.
 RenderDoc calls register() on load and unregister() on shutdown.
 """
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, Optional
 
 # qrenderdoc / renderdoc are only available when this package is loaded
 # inside the RenderDoc GUI. The headless worker entry point imports
@@ -19,8 +17,8 @@ from .context import GuiHandlerContext, HandlerContext
 
 # --- Module state ---
 
-_extension : Any           = None
-_server    : BridgeServer | None = None
+_extension : Any                    = None
+_server    : Optional[BridgeServer] = None
 
 
 def register(version: str, ctx: Any) -> None:
@@ -28,8 +26,23 @@ def register(version: str, ctx: Any) -> None:
 
     Sets up the handler context, registers the CaptureViewer, and
     starts the TCP bridge server.
+
+    Skipped entirely when ``AGENTIC_DISABLE_AUTOLOAD`` is set in the
+    environment. This is used by the Windows embedded-headless entry
+    point (see ``embedded_headless.py``), which runs as
+    ``qrenderdoc --script`` and provides its own ``EmbeddedHeadlessContext``
+    plus bridge. Without this skip, qrenderdoc's ``AlwaysLoad_Extensions``
+    auto-load would race the embedded script and bind a second bridge
+    on the same port (Windows' SO_REUSEADDR allows hijacking-style
+    coexistence), with incoming connections being routed to the
+    GUI-context bridge instead of the embedded one.
     """
     global _extension, _server
+
+    import os
+    if os.environ.get("AGENTIC_DISABLE_AUTOLOAD"):
+        print("[Agentic] AGENTIC_DISABLE_AUTOLOAD set; skipping auto-load")
+        return
 
     print(f"[Agentic] Registering (RenderDoc {version})")
 

--- a/src/extension/api_index.py
+++ b/src/extension/api_index.py
@@ -4,13 +4,9 @@ Introspects the live `renderdoc` module at startup to build a searchable
 index of all classes, methods, enums, and their docstrings.
 """
 
-from __future__ import annotations
-
 import inspect
 import re
-from typing import Any
-
-
+from typing import Any, List, Optional, Set
 # --- Synonyms ---
 
 # Maps common search terms to related API names. When a user searches for a
@@ -112,7 +108,7 @@ _SYNONYMS = {
 
 # --- Public API ---
 
-def build_index() -> list[dict]:
+def build_index() -> List[dict]:
     """Build the API reference index by introspecting the renderdoc module.
 
     Returns a list of entries, each with:
@@ -131,7 +127,7 @@ def build_index() -> list[dict]:
     return entries
 
 
-def search_index(index: list[dict], query: str) -> list[dict]:
+def search_index(index: List[dict], query: str) -> List[dict]:
     """Search the index for entries matching the query string.
 
     Matches against name and docstring content. Case-insensitive.
@@ -175,7 +171,7 @@ _CAMEL_SPLIT_RE = re.compile(
 )
 
 
-def _tokenize_name(name: str) -> list[str]:
+def _tokenize_name(name: str) -> List[str]:
     """Split an API name into lowercase tokens by CamelCase and underscores.
 
     Handles PascalCase, camelCase, SCREAMING_SNAKE, and mixed identifiers.
@@ -193,7 +189,7 @@ def _tokenize_name(name: str) -> list[str]:
     return tokens
 
 
-def _tokenize_query(query: str) -> list[str]:
+def _tokenize_query(query: str) -> List[str]:
     """Split a search query into lowercase tokens.
 
     Handles both natural language ("pipeline state") and identifier-style
@@ -324,7 +320,7 @@ def _score_query(entry: dict, query_lower: str) -> int:
     return 0
 
 
-def _score_tokens(query_tokens: list[str], name_tokens: list[str]) -> int:
+def _score_tokens(query_tokens: List[str], name_tokens: List[str]) -> int:
     """Score query tokens against name tokens.
 
     Returns 50 if all query tokens exactly match a name token, 45 if all
@@ -408,7 +404,7 @@ def _score_fuzzy(entry: dict, query_lower: str) -> int:
 
 # --- Module Walker ---
 
-def _walk_module(obj: Any, prefix: str, entries: list[dict], visited: set[int]) -> None:
+def _walk_module(obj: Any, prefix: str, entries: List[dict], visited: Set[int]) -> None:
     """Recursively enumerate members of a module or class.
 
     Walks public attributes of obj, classifying each as a class, enum,
@@ -459,7 +455,7 @@ def _walk_module(obj: Any, prefix: str, entries: list[dict], visited: set[int]) 
             _walk_class(member, qualified, entries, visited)
 
 
-def _walk_class(cls: type, prefix: str, entries: list[dict], visited: set[int]) -> None:
+def _walk_class(cls: type, prefix: str, entries: List[dict], visited: Set[int]) -> None:
     """Walk the members of a class, emitting methods and properties.
 
     Unlike _walk_module, this checks for property descriptors using
@@ -528,7 +524,7 @@ def _walk_class(cls: type, prefix: str, entries: list[dict], visited: set[int]) 
             })
 
 
-def _walk_enum_members(enum_cls: type, prefix: str, entries: list[dict]) -> None:
+def _walk_enum_members(enum_cls: type, prefix: str, entries: List[dict]) -> None:
     """Extract individual values from a SWIG-generated enum type.
 
     SWIG enums expose their members via a __members__ dict mapping
@@ -564,7 +560,7 @@ def _walk_enum_members(enum_cls: type, prefix: str, entries: list[dict]) -> None
 
 # --- Classification ---
 
-def _classify(obj: Any) -> str | None:
+def _classify(obj: Any) -> Optional[str]:
     """Classify a Python object as class, method, enum, or None.
 
     RenderDoc enums are SWIG-generated IntEnum-like types. They are
@@ -621,7 +617,7 @@ def _is_property_descriptor(obj: Any) -> bool:
 
 # --- Signature Extraction ---
 
-def _get_signature(obj: Any) -> str | None:
+def _get_signature(obj: Any) -> Optional[str]:
     """Extract a signature string from a callable.
 
     Tries inspect.signature first. When that fails (common for
@@ -650,7 +646,7 @@ _SWIG_SIG_RE = re.compile(
 )
 
 
-def _parse_docstring_signature(obj: Any) -> str | None:
+def _parse_docstring_signature(obj: Any) -> Optional[str]:
     """Parse a signature from the first line of a SWIG-style docstring.
 
     Returns a signature string like "(arg1, arg2) -> ReturnType", or

--- a/src/extension/bridge.py
+++ b/src/extension/bridge.py
@@ -15,14 +15,11 @@ Two implementations share a common dispatch:
                      Python/generated_cases.c.h tuple_alloc). Used only
                      when no Qt bindings are importable.
 """
-from __future__ import annotations
-
 import _thread
 import json
 import threading
 import traceback
-from typing import Any
-
+from typing import Any, Dict, Optional
 from .handlers import HANDLERS
 from .          import winsock
 
@@ -55,7 +52,7 @@ def _try_import_qt():
 
 # --- Shared dispatch ---
 
-def _dispatch(ctx: Any, request: dict[str, Any]) -> dict[str, Any]:
+def _dispatch(ctx: Any, request: Dict[str, Any]) -> Dict[str, Any]:
     """Run a single request's handler.
 
     Caller is responsible for serializing dispatches -- the replay API
@@ -90,12 +87,12 @@ class _QtBridge:
     def __init__(self, ctx: Any, port_range: range) -> None:
         self._ctx        = ctx
         self._port_range = port_range
-        self._port       : int | None         = None
+        self._port       : Optional[int]         = None
         self._server     : Any                = None
-        self._buffers    : dict[Any, bytearray] = {}
+        self._buffers    : Dict[Any, bytearray] = {}
 
     @property
-    def port(self) -> int | None:
+    def port(self) -> Optional[int]:
         return self._port
 
     def start(self) -> None:
@@ -188,7 +185,7 @@ class JsonSocket:
         self._conn   = conn
         self._buffer = b""
 
-    def read_request(self) -> dict[str, Any] | None:
+    def read_request(self) -> Optional[Dict[str, Any]]:
         """Read one newline-delimited JSON request. Blocks."""
         while b"\n" not in self._buffer:
             try:
@@ -202,7 +199,7 @@ class JsonSocket:
         line, self._buffer = self._buffer.split(b"\n", 1)
         return json.loads(line.decode("utf-8"))
 
-    def write_response(self, response: dict[str, Any]) -> None:
+    def write_response(self, response: Dict[str, Any]) -> None:
         """Write a JSON response followed by a newline."""
         data = json.dumps(response, separators=(",", ":")) + "\n"
         self._conn.sendall(data.encode("utf-8"))
@@ -214,16 +211,16 @@ class _ThreadedBridge:
     def __init__(self, ctx: Any, port_range: range) -> None:
         self._ctx           = ctx
         self._port_range    = port_range
-        self._port          : int | None            = None
+        self._port          : Optional[int]            = None
         self._server_socket : Any                   = None
         self._running       : bool                  = False
-        self._thread        : threading.Thread | None = None
+        self._thread        : Optional[threading.Thread] = None
         self._active_conns  : int                   = 0
         self._conn_lock                             = threading.Lock()
         self._dispatch_lock                         = threading.Lock()
 
     @property
-    def port(self) -> int | None:
+    def port(self) -> Optional[int]:
         return self._port
 
     def start(self) -> None:
@@ -234,6 +231,11 @@ class _ThreadedBridge:
         for port in self._port_range:
             try:
                 self._server_socket = winsock.Socket()
+                # SO_REUSEADDR so we can rebind a port the parent
+                # process (or a prior worker) just released. The MCP
+                # server's port-discovery probe also uses SO_REUSEADDR
+                # for the same reason.
+                self._server_socket.setsockopt_reuse()
                 self._server_socket.bind("127.0.0.1", port)
                 self._server_socket.listen(5)
                 self._port = port
@@ -348,7 +350,7 @@ class BridgeServer:
             self._impl = _ThreadedBridge(ctx, port_range)
 
     @property
-    def port(self) -> int | None:
+    def port(self) -> Optional[int]:
         return self._impl.port
 
     def start(self) -> None:

--- a/src/extension/context.py
+++ b/src/extension/context.py
@@ -16,13 +16,15 @@ controller. Two variants exist:
 Both expose the same surface so handlers and bind_utilities() are
 agnostic to which environment they're in.
 """
-from __future__ import annotations
-
-import concurrent.futures
-import queue
 import threading
-from collections.abc import Callable
-from typing          import Any
+from typing import Any, Callable, List, Optional, Tuple
+
+# ``concurrent.futures`` and ``queue`` transitively import ``socket`` via
+# ``multiprocessing``. qrenderdoc's embedded Python 3.6 ships without
+# ``_socket``, so a module-level import here would block the whole
+# extension from loading inside qrenderdoc — even though only the
+# external-worker HeadlessHandlerContext actually uses them. Import
+# them lazily in that class's methods instead.
 
 from .api_index import build_index
 
@@ -35,7 +37,7 @@ class _TrackedController:
     querying pipeline state without first selecting an event.
     """
 
-    def __init__(self, controller: Any, warnings: list[str]) -> None:
+    def __init__(self, controller: Any, warnings: List[str]) -> None:
         self._controller         = controller
         self._warnings           = warnings
         self._set_frame_called   = False
@@ -57,7 +59,7 @@ class _TrackedController:
     def __getattr__(self, name: str) -> Any:
         return getattr(self._controller, name)
 
-    def __dir__(self) -> list[str]:
+    def __dir__(self) -> List[str]:
         names = set(dir(self._controller))
         names.update(super().__dir__())
         return sorted(names)
@@ -79,11 +81,11 @@ class HandlerContext:
         self._server_port       : int         = 0
         self._capture_loaded    : bool        = False
         self._api_type          : Any         = None
-        self._capture_path      : str | None  = None
+        self._capture_path      : Optional[str]  = None
         self._event_count       : int         = 0
-        self._api_index         : dict | None = None
+        self._api_index         : Optional[dict] = None
         self._replay_controller : Any         = None
-        self._replay_warnings   : list[str]   = []
+        self._replay_warnings   : List[str]   = []
         self._bridge            : Any         = None
 
     # --- Public properties ---
@@ -93,7 +95,7 @@ class HandlerContext:
         return self._capture_loaded
 
     @property
-    def api_index(self) -> dict | None:
+    def api_index(self) -> Optional[dict]:
         return self._api_index
 
     @property
@@ -224,17 +226,24 @@ class HeadlessHandlerContext(HandlerContext):
 
     def __init__(self, remote_port: int, capture_path: str) -> None:
         super().__init__()
+        # Lazy imports — see module docstring for why these can't be at
+        # module scope (qrenderdoc Python ships without _socket).
+        import concurrent.futures as _futures
+        import queue as _queue
+        self._futures_mod = _futures
+        self._queue_mod   = _queue
+
         self._remote_port    = remote_port
         self._capture_path   = capture_path
         self._remote_server  : Any = None  # populated by replay thread
         self._controller_raw : Any = None  # populated by replay thread
         self._structured_file: Any = None
 
-        self._queue: "queue.Queue[Any]" = queue.Queue()
+        self._queue = _queue.Queue()
         self._stop = threading.Event()
         # Setup completion signal. Set to True on success, set with an
         # exception on failure. Constructor blocks on it.
-        self._setup_done: concurrent.futures.Future[bool] = concurrent.futures.Future()
+        self._setup_done = _futures.Future()
 
         self._replay_thread = threading.Thread(
             target = self._replay_loop,
@@ -274,7 +283,7 @@ class HeadlessHandlerContext(HandlerContext):
         """
         self._capture_loaded = True
 
-        def _populate(controller: Any) -> tuple[Any, int, Any]:
+        def _populate(controller: Any) -> Tuple[Any, int, Any]:
             try:
                 api_type = controller.GetAPIProperties().pipelineType
             except Exception:
@@ -314,7 +323,7 @@ class HeadlessHandlerContext(HandlerContext):
         if self._replay_controller is not None:
             return callback(self._replay_controller)
 
-        future: concurrent.futures.Future[Any] = concurrent.futures.Future()
+        future = self._futures_mod.Future()
 
         def worker(controller: Any) -> Any:
             tracked = _TrackedController(controller, self._replay_warnings)
@@ -365,7 +374,7 @@ class HeadlessHandlerContext(HandlerContext):
         while True:
             try:
                 item = self._queue.get_nowait()
-            except queue.Empty:
+            except self._queue_mod.Empty:
                 break
             if item is None:
                 continue
@@ -452,7 +461,7 @@ class HeadlessHandlerContext(HandlerContext):
             while not self._stop.is_set():
                 try:
                     item = self._queue.get(timeout=0.5)
-                except queue.Empty:
+                except self._queue_mod.Empty:
                     continue
 
                 if item is None:
@@ -483,6 +492,230 @@ class HeadlessHandlerContext(HandlerContext):
             except Exception:
                 pass
             self._remote_server = None
+
+
+class EmbeddedHeadlessContext(HandlerContext):
+    """Context for in-process replay inside qrenderdoc's embedded Python.
+
+    Used by the Windows headless path, where ``renderdoc.pyd`` is not
+    shipped as a standalone Python module — the bindings are only
+    reachable from inside ``qrenderdoc.exe`` (via ``qrenderdoc --script``).
+    Opens the capture locally via ``rd.OpenCaptureFile`` / ``OpenCapture``
+    rather than ``renderdoccmd remoteserver``, mirroring the path the
+    GUI uses for its own captures.
+
+    Same single-thread discipline as ``HeadlessHandlerContext``: one
+    dedicated replay thread owns every renderdoc call from OpenCapture
+    through CloseCapture. There is no heartbeat — there's no remote
+    connection to keep alive.
+
+    Synchronisation uses ``threading.Event`` rather than
+    ``concurrent.futures.Future`` because qrenderdoc's embedded Python 3.6
+    ships without ``_socket``, and ``concurrent.futures`` transitively
+    imports ``socket`` via ``multiprocessing``.
+
+    capture_path -- Absolute path to the .rdc file to open in-process.
+    """
+
+    headless = True
+
+    def __init__(self, capture_path: str) -> None:
+        super().__init__()
+        # ``queue`` is safe to import in qrenderdoc's Python (no _socket
+        # in its transitive imports).
+        import queue as _queue
+        self._queue_mod = _queue
+
+        self._capture_path    = capture_path
+        self._cap_file        : Any = None  # populated by replay thread
+        self._controller_raw  : Any = None  # populated by replay thread
+        self._structured_file : Any = None
+
+        self._queue = _queue.Queue()
+        self._stop  = threading.Event()
+
+        # Setup signal: set on success or after setup failure. Caller
+        # checks ``_setup_error`` after waiting.
+        self._setup_done  = threading.Event()
+        self._setup_error : Optional[BaseException] = None
+
+        self._replay_thread = threading.Thread(
+            target = self._replay_loop,
+            name   = "agentic-replay-embedded",
+            daemon = True,
+        )
+        self._replay_thread.start()
+
+        # Block the constructor until setup completes. Re-raise any
+        # setup exception in the caller's thread.
+        self._setup_done.wait()
+        if self._setup_error is not None:
+            raise self._setup_error
+
+    @property
+    def structured_file(self) -> Any:
+        return self._structured_file
+
+    def on_capture_loaded(self) -> None:
+        """Populate capture metadata and build the API index.
+
+        Mirrors HeadlessHandlerContext.on_capture_loaded. The metadata
+        read is issued via replay() so it runs on the replay thread.
+        """
+        self._capture_loaded = True
+
+        def _populate(controller: Any) -> Tuple[Any, int, Any]:
+            try:
+                api_type = controller.GetAPIProperties().pipelineType
+            except Exception:
+                api_type = None
+
+            try:
+                last_action = controller.GetLastAction()
+                last_eid    = last_action.eventId if last_action is not None else -1
+            except Exception:
+                # GetLastAction() may not be available on older RenderDoc
+                # builds; fall back to a recursive walk.
+                try:
+                    last_eid = _last_event_id(controller.GetRootActions())
+                except Exception:
+                    last_eid = -1
+
+            try:
+                sdfile = controller.GetStructuredFile()
+            except Exception:
+                sdfile = None
+
+            return (api_type, last_eid + 1 if last_eid >= 0 else 0, sdfile)
+
+        api_type, event_count, sdfile = self.replay(_populate)
+        self._api_type        = api_type
+        self._event_count     = event_count
+        self._structured_file = sdfile
+
+        if self._api_index is None:
+            self._api_index = build_index()
+
+    def on_capture_closed(self) -> None:
+        super().on_capture_closed()
+        self._structured_file = None
+
+    def replay(self, callback: Callable[[Any], Any]) -> Any:
+        if self._stop.is_set():
+            raise RuntimeError("worker is shutting down")
+
+        self._replay_warnings = []
+
+        # Re-entrant: utilities may call replay() from within a callback.
+        if self._replay_controller is not None:
+            return callback(self._replay_controller)
+
+        # threading.Event + a result dict, since concurrent.futures isn't
+        # importable inside qrenderdoc (see module docstring).
+        result : dict = {}
+        done   = threading.Event()
+
+        def wrapper(controller: Any) -> None:
+            tracked = _TrackedController(controller, self._replay_warnings)
+            self._replay_controller = tracked
+            try:
+                result["value"] = callback(tracked)
+            except BaseException as e:
+                result["error"] = e
+            finally:
+                self._replay_controller = None
+                done.set()
+
+        self._queue.put(wrapper)
+        done.wait()
+
+        if "error" in result:
+            raise result["error"]
+        return result.get("value")
+
+    def invoke_ui(self, callback: Callable[[], None]) -> None:
+        raise RuntimeError("UI is not available in embedded headless mode")
+
+    def shutdown(self) -> None:
+        """Signal the replay thread to exit and reap it. Idempotent."""
+        if self._stop.is_set():
+            return
+
+        self._stop.set()
+        self._queue.put(None)  # sentinel
+
+        if self._replay_thread.is_alive():
+            self._replay_thread.join(timeout=15.0)
+
+        # Drain any queued work the replay loop didn't process.
+        while True:
+            try:
+                item = self._queue.get_nowait()
+            except self._queue_mod.Empty:
+                break
+            # Queued items here are wrapper callables that handle their
+            # own result-passing via shared closures — there's nothing
+            # to cancel from the outside; the wait()s on the caller side
+            # will block until shutdown is observed.
+
+        self._capture_loaded = False
+
+    def _replay_loop(self) -> None:
+        """Open the capture, drain the queue, tear down. All on this thread."""
+        # --- Phase 1: setup ---
+        import renderdoc as rd
+
+        try:
+            cap_file = rd.OpenCaptureFile()
+            status = cap_file.OpenFile(self._capture_path, "", None)
+            if status.code != rd.ResultCode.Succeeded:
+                raise RuntimeError("OpenFile failed: " + str(status.code))
+
+            status, controller = cap_file.OpenCapture(rd.ReplayOptions(), None)
+            if status.code != rd.ResultCode.Succeeded:
+                try:
+                    cap_file.Shutdown()
+                except Exception:
+                    pass
+                raise RuntimeError("OpenCapture failed: " + str(status.code))
+
+            self._cap_file       = cap_file
+            self._controller_raw = controller
+        except BaseException as e:
+            self._setup_error = e
+            self._setup_done.set()
+            return
+
+        self._setup_done.set()
+
+        # --- Phase 2: work ---
+        try:
+            while not self._stop.is_set():
+                try:
+                    item = self._queue.get(timeout=0.5)
+                except self._queue_mod.Empty:
+                    continue
+                if item is None:
+                    break
+                try:
+                    item(self._controller_raw)
+                except BaseException:
+                    import traceback
+                    traceback.print_exc()
+        finally:
+            # --- Phase 3: teardown (same thread that opened them) ---
+            try:
+                if self._controller_raw is not None:
+                    self._controller_raw.Shutdown()
+            except Exception:
+                pass
+            self._controller_raw = None
+            try:
+                if self._cap_file is not None:
+                    self._cap_file.Shutdown()
+            except Exception:
+                pass
+            self._cap_file = None
 
 
 def _last_event_id(actions: list) -> int:

--- a/src/extension/embedded_headless.py
+++ b/src/extension/embedded_headless.py
@@ -1,0 +1,170 @@
+"""Embedded headless entry point — runs inside qrenderdoc's --script.
+
+Used on Windows where ``renderdoc.pyd`` is not shipped as a standalone
+Python module: the SWIG bindings are statically compiled into
+``qrenderdoc.exe`` and only accessible from its embedded Python. We run
+our headless protocol inside qrenderdoc's interpreter via ``--script``,
+which runs before qrenderdoc opens its main UI: as long as this script
+never returns, the UI never appears. On shutdown we call
+``os._exit(0)`` so qrenderdoc skips its UI step.
+
+Invoked via::
+
+    qrenderdoc.exe --script <path-to-this-file>
+
+Configuration (env vars; ``sys.argv`` is empty inside ``--script``):
+
+    AGENTIC_EMBEDDED_CAPTURE     -- absolute path to the .rdc file.
+    AGENTIC_EMBEDDED_PORT_MIN    -- start of the JSON-bridge port range.
+    AGENTIC_EMBEDDED_PORT_MAX    -- end (inclusive) of that range.
+    AGENTIC_EMBEDDED_PKG_PARENT  -- directory containing the
+                                    ``extension`` package; prepended to
+                                    sys.path so we can import from it.
+
+Diagnostics are appended to
+``%TEMP%/agentic-renderdoc-embedded-<port>.log`` because qrenderdoc as
+a GUI subprocess produces no visible stdout/stderr. The port suffix
+prevents collisions between concurrent workers writing to the same file.
+
+This file is intentionally short. The actual replay context, bridge
+server, and handlers live in the ``extension`` package — sharing all
+the work that was already done to make those files 3.6-compatible.
+"""
+# NOTE: no `from __future__ import annotations` — qrenderdoc Python 3.6
+# does not understand that import.
+
+import os
+import sys
+import time
+import traceback
+
+
+_DEFAULT_PORT_MIN = 19876
+_DEFAULT_PORT_MAX = 19885
+
+
+def _log_path(port):
+    base = os.environ.get("TEMP") or os.environ.get("TMP") or "."
+    return os.path.join(base, "agentic-renderdoc-embedded-{}.log".format(port))
+
+
+def _log(port, msg):
+    """Append to the per-port diagnostic log. Best-effort."""
+    try:
+        with open(_log_path(port), "a", encoding="utf-8") as f:
+            f.write("[{:.3f}] {}\n".format(time.time(), msg))
+    except Exception:
+        pass
+
+
+def main():
+    capture_path = os.environ.get("AGENTIC_EMBEDDED_CAPTURE", "")
+    try:
+        port_min = int(os.environ.get("AGENTIC_EMBEDDED_PORT_MIN", str(_DEFAULT_PORT_MIN)))
+        port_max = int(os.environ.get("AGENTIC_EMBEDDED_PORT_MAX", str(_DEFAULT_PORT_MAX)))
+    except ValueError:
+        port_min, port_max = _DEFAULT_PORT_MIN, _DEFAULT_PORT_MAX
+
+    # Diagnostic log path is port-suffixed; log to the configured range's
+    # start until we have an actual bound port.
+    log = lambda msg: _log(port_min, msg)
+    log("=== embedded_headless start ===")
+    log("python: " + sys.version)
+
+    if not capture_path or not os.path.isfile(capture_path):
+        log("AGENTIC_EMBEDDED_CAPTURE missing or not a file: " + repr(capture_path))
+        os._exit(2)
+
+    # Make the ``extension`` package importable. ``__file__`` isn't always
+    # populated inside ``qrenderdoc --script``, so the spawning side
+    # passes the package's parent dir via env var.
+    pkg_parent = os.environ.get("AGENTIC_EMBEDDED_PKG_PARENT", "")
+    if not pkg_parent:
+        try:
+            pkg_parent = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        except NameError:
+            log("AGENTIC_EMBEDDED_PKG_PARENT unset and __file__ unavailable")
+            os._exit(4)
+    if pkg_parent and pkg_parent not in sys.path:
+        sys.path.insert(0, pkg_parent)
+
+    try:
+        import renderdoc as rd
+    except Exception:
+        log("renderdoc import failed:\n" + traceback.format_exc())
+        os._exit(3)
+
+    try:
+        rd.InitialiseReplay(rd.GlobalEnvironment(), [])
+    except Exception:
+        # Already initialised inside qrenderdoc — non-fatal.
+        log("InitialiseReplay warning (continuing)")
+
+    from extension.context import EmbeddedHeadlessContext
+    from extension.bridge  import BridgeServer
+    import extension.handlers  # noqa: F401 — registers handlers in module-level HANDLERS dict
+
+    ctx    = None
+    bridge = None
+
+    try:
+        ctx = EmbeddedHeadlessContext(capture_path=capture_path)
+        log("capture opened: " + capture_path)
+        ctx.on_capture_loaded()
+
+        # force_threaded=True: we cannot drive qrenderdoc's Qt event loop
+        # because that loop is what would open the UI. The threaded
+        # backend uses winsock + threads, no Qt dependency.
+        bridge = BridgeServer(
+            ctx,
+            port_range     = range(port_min, port_max + 1),
+            force_threaded = True,
+        )
+        bridge.start()
+        if bridge.port is None:
+            log("bridge failed to bind in range {}-{}".format(port_min, port_max))
+            os._exit(6)
+
+        # Re-target the log to the actual bound port.
+        log = lambda msg, _p=bridge.port: _log(_p, msg)
+        log("bridge bound on localhost:{}".format(bridge.port))
+
+        ctx._server_port = bridge.port
+        ctx._bridge      = bridge
+
+        # Block until the bridge stops. The shutdown handler runs
+        # bridge.stop() on a background thread; we poll the threaded
+        # backend's _running flag here. Sleep is fine — only fires
+        # while waiting for shutdown.
+        impl = getattr(bridge, "_impl", None)
+        while True:
+            running = getattr(impl, "_running", None) if impl is not None else None
+            if not running:
+                break
+            time.sleep(0.5)
+        log("bridge stopped; exiting")
+    except Exception:
+        log("startup or run failed:\n" + traceback.format_exc())
+    finally:
+        if bridge is not None:
+            try:
+                bridge.stop()
+            except Exception:
+                pass
+        if ctx is not None:
+            try:
+                ctx.shutdown()
+            except Exception:
+                pass
+        try:
+            rd.ShutdownReplay()
+        except Exception:
+            pass
+
+    # Bypass qrenderdoc's main() — never reach the UI launch step.
+    # sys.exit() would raise SystemExit which qrenderdoc may catch; the
+    # underscored variant terminates the whole process.
+    os._exit(0)
+
+
+main()

--- a/src/extension/handlers.py
+++ b/src/extension/handlers.py
@@ -2,30 +2,27 @@
 
 Handlers: eval, api_index, instance_info, get_texture, reload, shutdown.
 """
-from __future__ import annotations
-
 import traceback
-from collections.abc import Callable
-from typing          import Any
+from typing import Any, Callable, Dict, List, Optional
 
 from .api_index import search_index
 
 # Populated at registration time.
-HANDLERS: dict[str, dict[str, Any]] = {}
+HANDLERS = {}  # type: Dict[str, Dict[str, Any]]
 
 # Serializer dispatch table, keyed by RenderDoc type name.
 # Built lazily on first use since the serialize module imports renderdoc,
 # which may not be available during testing.
-_SERIALIZER_MAP: dict[str, Callable[..., Any]] | None = None
+_SERIALIZER_MAP = None  # type: Optional[Dict[str, Callable[..., Any]]]
 
 
 def handler(
     name: str,
     description: str = "",
-    schema: dict[str, Any] | None = None,
-) -> Callable[[Callable[..., dict[str, Any]]], Callable[..., dict[str, Any]]]:
+    schema: Optional[Dict[str, Any]] = None,
+) -> Callable[[Callable[..., Dict[str, Any]]], Callable[..., Dict[str, Any]]]:
     """Decorator to register a command handler."""
-    def decorator(func: Callable[..., dict[str, Any]]) -> Callable[..., dict[str, Any]]:
+    def decorator(func: Callable[..., Dict[str, Any]]) -> Callable[..., Dict[str, Any]]:
         HANDLERS[name] = {
             "func"        : func,
             "description" : description,
@@ -45,7 +42,7 @@ def handler(
         "required":   ["code"],
     },
 )
-def handle_eval(ctx: Any, params: dict[str, Any]) -> dict[str, Any]:
+def handle_eval(ctx: Any, params: Dict[str, Any]) -> Dict[str, Any]:
     """Execute arbitrary Python and return the result of the last expression.
 
     Builds a namespace with RenderDoc globals and utility modules, runs the
@@ -95,7 +92,7 @@ def handle_eval(ctx: Any, params: dict[str, Any]) -> dict[str, Any]:
         "required": ["query"],
     },
 )
-def handle_api_index(ctx: Any, params: dict[str, Any]) -> dict[str, Any]:
+def handle_api_index(ctx: Any, params: Dict[str, Any]) -> Dict[str, Any]:
     """Search the cached API index for matching entries.
 
     Returns up to `limit` results from the pre-built API reference index.
@@ -129,7 +126,7 @@ def handle_api_index(ctx: Any, params: dict[str, Any]) -> dict[str, Any]:
     description="Return metadata about this RenderDoc instance.",
     schema={},
 )
-def handle_instance_info(ctx: Any, params: dict[str, Any]) -> dict[str, Any]:
+def handle_instance_info(ctx: Any, params: Dict[str, Any]) -> Dict[str, Any]:
     """Return port, capture state, API type, path, and event count."""
     # Resolve the API type name from the SWIG enum. The enum wrapper may
     # or may not expose .name depending on the RenderDoc build.
@@ -172,7 +169,7 @@ def handle_instance_info(ctx: Any, params: dict[str, Any]) -> dict[str, Any]:
         "required": ["resource_id"],
     },
 )
-def handle_get_texture(ctx: Any, params: dict[str, Any]) -> dict[str, Any]:
+def handle_get_texture(ctx: Any, params: Dict[str, Any]) -> Dict[str, Any]:
     """Read raw texture bytes and return them base64-encoded with format metadata.
 
     Uses GetTextureData for a direct memory read rather than SaveTexture,
@@ -194,7 +191,7 @@ def handle_get_texture(ctx: Any, params: dict[str, Any]) -> dict[str, Any]:
     slice_param = params.get("slice", 0)
     sample      = params.get("sample", 0)
 
-    def callback(controller: Any) -> dict[str, Any]:
+    def callback(controller: Any) -> Dict[str, Any]:
         # Find the matching texture by comparing serialized resource IDs.
         tex = None
         for t in controller.GetTextures():
@@ -247,7 +244,7 @@ def handle_get_texture(ctx: Any, params: dict[str, Any]) -> dict[str, Any]:
     description="Hot-reload extension modules without restarting RenderDoc.",
     schema={},
 )
-def handle_reload(ctx: Any, params: dict[str, Any]) -> dict[str, Any]:
+def handle_reload(ctx: Any, params: Dict[str, Any]) -> Dict[str, Any]:
     """Reload business-logic modules in dependency order.
 
     Leaves winsock and bridge untouched (infrastructure). Mutates the
@@ -298,7 +295,7 @@ def handle_reload(ctx: Any, params: dict[str, Any]) -> dict[str, Any]:
     description="Request the bridge server to stop accepting connections and exit.",
     schema={},
 )
-def handle_shutdown(ctx: Any, params: dict[str, Any]) -> dict[str, Any]:
+def handle_shutdown(ctx: Any, params: Dict[str, Any]) -> Dict[str, Any]:
     """Trigger a graceful bridge shutdown.
 
     For headless workers, this also tears down the replay thread and
@@ -336,7 +333,7 @@ def handle_shutdown(ctx: Any, params: dict[str, Any]) -> dict[str, Any]:
 
 # --- Internal helpers ---
 
-def _build_namespace(ctx: Any, captured_output: list[str]) -> dict[str, Any]:
+def _build_namespace(ctx: Any, captured_output: List[str]) -> Dict[str, Any]:
     """Build the execution namespace for eval, including utilities.
 
     Injects RenderDoc modules (rd, qrd), the handler context, the serialize
@@ -389,7 +386,7 @@ def _build_namespace(ctx: Any, captured_output: list[str]) -> dict[str, Any]:
     return ns
 
 
-def _exec_with_result(code: str, namespace: dict[str, Any]) -> Any:
+def _exec_with_result(code: str, namespace: Dict[str, Any]) -> Any:
     """Execute code and return the value of the last expression, if any.
 
     Splits the code into statements and the final expression. Executes all
@@ -416,7 +413,7 @@ def _exec_with_result(code: str, namespace: dict[str, Any]) -> Any:
         return None
 
 
-def _format_error(exc: Exception, code: str, namespace: dict[str, Any]) -> dict[str, Any]:
+def _format_error(exc: Exception, code: str, namespace: Dict[str, Any]) -> Dict[str, Any]:
     """Format an exception with stack trace, failing line, and contextual hints.
 
     Returns a dict with:
@@ -482,7 +479,7 @@ def _format_error(exc: Exception, code: str, namespace: dict[str, Any]) -> dict[
     }
 
 
-def _extract_failing_line(exc: Exception, code: str = "") -> str | None:
+def _extract_failing_line(exc: Exception, code: str = "") -> Optional[str]:
     """Extract the source line that caused the exception.
 
     Prefers frames from the user's eval code (filename ``<eval>``). Falls
@@ -522,7 +519,7 @@ def _extract_failing_line(exc: Exception, code: str = "") -> str | None:
     return best
 
 
-def _get_serializer_map() -> dict[str, Callable[..., Any]]:
+def _get_serializer_map() -> Dict[str, Callable[..., Any]]:
     """Lazily build the type-name-to-serializer dispatch table.
 
     Deferred because the serialize module imports renderdoc at the top

--- a/src/extension/headless.py
+++ b/src/extension/headless.py
@@ -26,8 +26,6 @@ Options:
         Override the renderdoccmd executable path. Defaults to
         whichever ``renderdoccmd`` is found on PATH.
 """
-from __future__ import annotations
-
 import argparse
 import os
 import shutil
@@ -42,6 +40,7 @@ from pathlib import Path
 from . import renderdoc_locate
 from .bridge  import BridgeServer
 from .context import HeadlessHandlerContext
+from typing import List, Optional, Tuple
 
 
 _DEFAULT_PORT_MIN        = 19876
@@ -50,7 +49,7 @@ _DEFAULT_REMOTE_PORT_MIN = 39920
 _DEFAULT_REMOTE_PORT_MAX = 39929
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(
         prog        = "agentic-renderdoc-headless",
         description = "Headless RenderDoc replay worker (renderdoccmd-backed).",
@@ -182,7 +181,7 @@ def _die_with_parent() -> None:
         pass
 
 
-def _spawn_remoteserver(renderdoccmd: str, port_range: range) -> tuple[subprocess.Popen, int]:
+def _spawn_remoteserver(renderdoccmd: str, port_range: range) -> Tuple[subprocess.Popen, int]:
     """Spawn renderdoccmd remoteserver on the first free port in range.
 
     Returns (Popen, port). Raises RuntimeError if every port is busy or
@@ -201,7 +200,7 @@ def _spawn_remoteserver(renderdoccmd: str, port_range: range) -> tuple[subproces
     env["VK_LOADER_LAYERS_DISABLE"]             = "*"
     env["DISABLE_VK_LAYER_RENDERDOC_Capture_1"] = "1"
 
-    last_err: Exception | None = None
+    last_err: Optional[Exception] = None
     for port in port_range:
         # Pre-flight: check the port is locally bindable. renderdoccmd
         # would otherwise refuse silently or print to its stderr.

--- a/src/extension/renderdoc_locate.py
+++ b/src/extension/renderdoc_locate.py
@@ -24,14 +24,13 @@ with the candidate directory prepended to ``sys.path`` and the matching
 shared library preloaded with ``RTLD_GLOBAL``. The first candidate that
 imports cleanly wins.
 """
-from __future__ import annotations
-
 import ctypes
 import importlib
 import os
 import shutil
 import sys
 from pathlib import Path
+from typing import List, Optional, Set, Tuple
 
 
 # --- Platform-specific names ---
@@ -81,7 +80,7 @@ def setup() -> dict:
             "RenderDoc install root, or install RenderDoc system-wide."
         )
 
-    tried: list[str] = []
+    tried = []  # type: List[str]
     for python_dir, library_path in candidates:
         try:
             _try_load(python_dir, library_path)
@@ -102,7 +101,7 @@ def setup() -> dict:
 
 # --- Internals ---
 
-def _try_load(python_dir: Path, library_path: Path | None) -> None:
+def _try_load(python_dir: Path, library_path: Optional[Path]) -> None:
     """Attempt to import the renderdoc module from python_dir.
 
     Preloads librenderdoc with RTLD_GLOBAL when a path is supplied so
@@ -149,9 +148,9 @@ def _iter_candidates():
     optional — when omitted, no preload is performed and we trust the
     OS dynamic linker.
     """
-    seen: set[tuple[str, str]] = set()
+    seen = set()  # type: Set[Tuple[str, str]]
 
-    def emit(python_dir: Path, library_path: Path | None):
+    def emit(python_dir: Path, library_path: Optional[Path]):
         key = (str(python_dir), str(library_path) if library_path else "")
         if key in seen:
             return None
@@ -250,7 +249,7 @@ def _has_python_module(d: Path) -> bool:
     return False
 
 
-def _find_library_under(root: Path) -> Path | None:
+def _find_library_under(root: Path) -> Optional[Path]:
     """Locate the librenderdoc shared library under root, if present."""
     candidates = (
         root / "lib" / _LIB_NAME,

--- a/src/extension/serialize.py
+++ b/src/extension/serialize.py
@@ -4,10 +4,7 @@ Converts RenderDoc's SWIG-wrapped types into plain dicts suitable for
 JSON transport. Ported from orb-renderdoc v1.
 """
 
-from __future__ import annotations
-
-from typing import Any
-
+from typing import Any, List
 import renderdoc as rd
 
 
@@ -61,7 +58,7 @@ def api_properties(props: rd.APIProperties) -> dict:
 
 # --- Actions ---
 
-def action_flags(flags: rd.ActionFlags) -> list[str]:
+def action_flags(flags: rd.ActionFlags) -> List[str]:
     """Convert an ActionFlags bitmask to a list of flag name strings."""
     result = []
 

--- a/src/extension/utilities.py
+++ b/src/extension/utilities.py
@@ -5,15 +5,10 @@ and UI navigation helpers. Functions that need access to the replay controller
 or UI thread are bound to a HandlerContext via closures.
 """
 
-from __future__ import annotations
-
 import inspect as _inspect
 import math
 import struct
-from collections.abc import Callable
-from typing import Any
-
-
+from typing import Any, Callable, Dict, List, Optional, Tuple
 try:
     import renderdoc as rd
 except ImportError:
@@ -82,7 +77,7 @@ def _inspect_enum(obj: Any) -> dict:
     }
 
 
-def _extract_int_enum_members(cls: type) -> list[dict]:
+def _extract_int_enum_members(cls: type) -> List[dict]:
     """Extract named constants from a SWIG int-enum class.
 
     Returns a list of {name, value} dicts, or an empty list if this
@@ -185,7 +180,7 @@ def _inspect_object(obj: Any) -> dict:
     }
 
 
-def _get_signature(func: Any) -> str | None:
+def _get_signature(func: Any) -> Optional[str]:
     """Get a function's call signature as a string.
 
     Tries inspect.signature first. Falls back to parsing the first line
@@ -207,7 +202,7 @@ def _get_signature(func: Any) -> str | None:
     return None
 
 
-def _first_line(doc: str | None) -> str | None:
+def _first_line(doc: Optional[str]) -> Optional[str]:
     """Return the first non-empty line of a docstring, or None."""
     if not doc:
         return None
@@ -220,7 +215,7 @@ def _first_line(doc: str | None) -> str | None:
 
 # --- Pipeline State Diffing ---
 
-def _deep_diff(a: Any, b: Any) -> dict | None:
+def _deep_diff(a: Any, b: Any) -> Optional[dict]:
     """Recursively diff two dicts, returning only changed paths.
 
     For nested dicts, recurses and only includes keys whose subtrees
@@ -262,7 +257,7 @@ def _deep_diff(a: Any, b: Any) -> dict | None:
     return None
 
 
-def _annotate_resource_names(diff: dict, name_map: dict[str, str]) -> dict:
+def _annotate_resource_names(diff: dict, name_map: Dict[str, str]) -> dict:
     """Walk a diff dict and annotate leaf values that are resource IDs.
 
     For each leaf {"before": x, "after": y}, if x or y is a string
@@ -315,7 +310,7 @@ def make_diff_state(ctx: Any) -> Callable[..., dict]:
         """
         from . import serialize
 
-        def _snapshot_push_constants(controller: Any) -> str | None:
+        def _snapshot_push_constants(controller: Any) -> Optional[str]:
             """Try to capture Vulkan push constant data.
 
             Returns the raw bytes as a hex string, or None for
@@ -330,7 +325,7 @@ def make_diff_state(ctx: Any) -> Callable[..., dict]:
                 pass
             return None
 
-        def _snapshot_both(controller: Any) -> tuple[dict, dict, dict[str, str]]:
+        def _snapshot_both(controller: Any) -> Tuple[dict, dict, Dict[str, str]]:
             controller.SetFrameEvent(eid_a, True)
             state_a = serialize.pipeline_state(controller.GetPipelineState())
             push_a  = _snapshot_push_constants(controller)
@@ -483,7 +478,7 @@ def summarize_data(values: Any) -> dict:
 
 # --- Action Flags ---
 
-def action_flags(flags: Any) -> list[str]:
+def action_flags(flags: Any) -> List[str]:
     """Decode an ActionDescription flags bitmask into human-readable names.
 
     Introspects rd.ActionFlags to discover all known flag members, then
@@ -568,7 +563,7 @@ def decode_push_constants(controller: Any, stage: Any) -> dict:
 
 # --- Action Tree ---
 
-def make_get_draw_calls(ctx: Any) -> Callable[..., list[dict]]:
+def make_get_draw_calls(ctx: Any) -> Callable[..., List[dict]]:
     """Create a get_draw_calls function bound to the given HandlerContext.
 
     The returned closure walks the action tree and collects all leaf draw
@@ -577,7 +572,7 @@ def make_get_draw_calls(ctx: Any) -> Callable[..., list[dict]]:
 
     ctx -- HandlerContext with replay() access and structured_file.
     """
-    def get_draw_calls(controller: Any = None) -> list[dict]:
+    def get_draw_calls(controller: Any = None) -> List[dict]:
         """Collect all leaf draw calls in the frame.
 
         Recursively walks the action tree from GetRootActions(), filtering
@@ -591,8 +586,8 @@ def make_get_draw_calls(ctx: Any) -> Callable[..., list[dict]]:
 
         Returns a list of {"eventId": int, "name": str}.
         """
-        def _collect(ctrl: Any) -> list[dict]:
-            def _recurse(actions: list) -> list[dict]:
+        def _collect(ctrl: Any) -> List[dict]:
+            def _recurse(actions: list) -> List[dict]:
                 draws = []
                 for action in actions:
                     if action.flags & rd.ActionFlags.Drawcall:
@@ -619,7 +614,7 @@ def make_get_draw_calls(ctx: Any) -> Callable[..., list[dict]]:
     return get_draw_calls
 
 
-def make_get_all_actions(ctx: Any) -> Callable[..., list[dict]]:
+def make_get_all_actions(ctx: Any) -> Callable[..., List[dict]]:
     """Create a get_all_actions function bound to the given HandlerContext.
 
     The returned closure walks the entire action tree and returns every
@@ -629,7 +624,7 @@ def make_get_all_actions(ctx: Any) -> Callable[..., list[dict]]:
 
     ctx -- HandlerContext with replay() access and structured_file.
     """
-    def get_all_actions(controller: Any = None) -> list[dict]:
+    def get_all_actions(controller: Any = None) -> List[dict]:
         """Collect all actions in the frame as a flat list.
 
         Recursively walks the action tree from GetRootActions(), emitting
@@ -643,8 +638,8 @@ def make_get_all_actions(ctx: Any) -> Callable[..., list[dict]]:
 
         Returns a list of {"eventId": int, "name": str, "flags": [str]}.
         """
-        def _collect(ctrl: Any) -> list[dict]:
-            def _recurse(actions: list) -> list[dict]:
+        def _collect(ctrl: Any) -> List[dict]:
+            def _recurse(actions: list) -> List[dict]:
                 result = []
                 for a in actions:
                     result.append({
@@ -682,7 +677,7 @@ def make_describe_draw(ctx: Any) -> Callable[..., dict]:
 
     ctx -- HandlerContext with replay() access and structured_file.
     """
-    def describe_draw(controller: Any = None, eventId: int | None = None) -> dict:
+    def describe_draw(controller: Any = None, eventId: Optional[int] = None) -> dict:
         """Summarize pipeline state and draw parameters at an event.
 
         Moves the replay cursor to the given event, snapshots the full
@@ -848,7 +843,7 @@ def make_get_resource_name(ctx: Any) -> Callable[..., str]:
 
     ctx -- HandlerContext with replay() access.
     """
-    cache: dict[Any, str] = {}
+    cache: Dict[Any, str] = {}
 
     def _build_cache(controller: Any) -> None:
         """Fetch all resources and populate the name cache."""
@@ -969,7 +964,7 @@ def make_highlight_drawcall(ctx: Any) -> Callable[..., dict]:
 
 # --- Binding ---
 
-def bind_utilities(ctx: Any) -> dict[str, Any]:
+def bind_utilities(ctx: Any) -> Dict[str, Any]:
     """Create all utility functions bound to the given HandlerContext.
 
     Returns a dict suitable for merging into the eval handler's

--- a/src/extension/winsock.py
+++ b/src/extension/winsock.py
@@ -218,7 +218,7 @@ else:
         recv, close. Used as a context manager for automatic cleanup.
         """
 
-        def __init__(self, handle: int | None = None):
+        def __init__(self, handle=None):  # type: (int | None) -> None
             """Create a new TCP socket, or wrap an existing handle.
 
             Args:

--- a/src/server/client.py
+++ b/src/server/client.py
@@ -92,6 +92,32 @@ def _format_dead_error(e: "WorkerDeadError") -> dict:
     }
 
 
+def _find_qrenderdoc() -> str | None:
+    """Locate ``qrenderdoc.exe`` (or ``qrenderdoc`` on POSIX) for spawning.
+
+    Tries PATH first via ``shutil.which``, then the standard Windows
+    install location. Returns the resolved absolute path or None if not
+    found.
+    """
+    import shutil
+    name = "qrenderdoc.exe" if sys.platform == "win32" else "qrenderdoc"
+    found = shutil.which(name)
+    if found:
+        return found
+    if sys.platform == "win32":
+        candidates = [
+            r"C:\Program Files\RenderDoc\qrenderdoc.exe",
+            os.path.join(
+                os.environ.get("LOCALAPPDATA", ""),
+                "Programs", "RenderDoc", "qrenderdoc.exe",
+            ),
+        ]
+        for c in candidates:
+            if c and os.path.isfile(c):
+                return c
+    return None
+
+
 def _die_with_parent() -> None:
     """preexec_fn: ask the kernel to SIGKILL us when our parent dies.
 
@@ -533,23 +559,44 @@ class RenderDocClient:
                 f"{_PORT_RANGE.start}-{_PORT_RANGE.stop - 1}"
             )
 
-        remote_port = self._first_free_port(_REMOTE_PORT_RANGE)
-        if remote_port is None:
-            raise RuntimeError(
-                f"no free port in remote range "
-                f"{_REMOTE_PORT_RANGE.start}-{_REMOTE_PORT_RANGE.stop - 1}"
-            )
+        # On Windows the standard RenderDoc distribution does not ship
+        # ``renderdoc.pyd`` for external Python — the SWIG bindings are
+        # compiled into ``qrenderdoc.exe``. Run headless logic inside
+        # qrenderdoc's embedded Python via ``--script``; it exits via
+        # ``os._exit(0)`` before qrenderdoc ever opens its main UI, and
+        # uses in-process ``rd.OpenCaptureFile`` rather than
+        # ``renderdoccmd remoteserver``. No remote port needed.
+        windows_embedded = sys.platform == "win32"
 
-        cmd = [
-            sys.executable,
-            "-u",
-            "-m", "extension.headless",
-            str(capture.resolve()),
-            "--port-min",        str(bridge_port),
-            "--port-max",        str(bridge_port),
-            "--remote-port-min", str(remote_port),
-            "--remote-port-max", str(remote_port),
-        ]
+        if windows_embedded:
+            remote_port = None
+            qrd_path = _find_qrenderdoc()
+            if qrd_path is None:
+                raise RuntimeError(
+                    "could not locate qrenderdoc.exe (looked on PATH and "
+                    "%ProgramFiles%\\RenderDoc); install RenderDoc system-wide"
+                )
+            embedded_script = (
+                Path(__file__).resolve().parent.parent / "extension" / "embedded_headless.py"
+            )
+            cmd = [qrd_path, "--script", str(embedded_script)]
+        else:
+            remote_port = self._first_free_port(_REMOTE_PORT_RANGE)
+            if remote_port is None:
+                raise RuntimeError(
+                    f"no free port in remote range "
+                    f"{_REMOTE_PORT_RANGE.start}-{_REMOTE_PORT_RANGE.stop - 1}"
+                )
+            cmd = [
+                sys.executable,
+                "-u",
+                "-m", "extension.headless",
+                str(capture.resolve()),
+                "--port-min",        str(bridge_port),
+                "--port-max",        str(bridge_port),
+                "--remote-port-min", str(remote_port),
+                "--remote-port-max", str(remote_port),
+            ]
 
         env = os.environ.copy()
         # Make sure the extension/ package is importable.
@@ -571,14 +618,35 @@ class RenderDocClient:
         env["VK_LOADER_LAYERS_DISABLE"]                = "*"
         env["DISABLE_VK_LAYER_RENDERDOC_Capture_1"]    = "1"
 
-        proc = subprocess.Popen(
-            cmd,
-            stdin      = subprocess.DEVNULL,
-            stdout     = subprocess.DEVNULL,
-            stderr     = subprocess.PIPE,
-            env        = env,
-            preexec_fn = _die_with_parent if sys.platform.startswith("linux") else None,
-        )
+        if windows_embedded:
+            # qrenderdoc does not populate sys.argv inside --script, so
+            # the embedded script reads its config from env vars instead.
+            # PKG_PARENT is the directory the script prepends to sys.path
+            # so it can ``from extension.context import ...`` etc.
+            # (relying on __file__ would be flaky — qrenderdoc doesn't
+            # always populate it under --script).
+            env["AGENTIC_EMBEDDED_CAPTURE"]    = str(capture.resolve())
+            env["AGENTIC_EMBEDDED_PORT_MIN"]   = str(bridge_port)
+            env["AGENTIC_EMBEDDED_PORT_MAX"]   = str(bridge_port)
+            env["AGENTIC_EMBEDDED_PKG_PARENT"] = str(src_dir)
+            # Prevent qrenderdoc's AlwaysLoad_Extensions auto-load from
+            # binding a competing bridge on the same port. With Windows'
+            # SO_REUSEADDR semantics both bridges would coexist as
+            # listeners and incoming connections would routinely hit the
+            # GuiHandlerContext-backed one instead of ours. The
+            # extension's register() checks this var and no-ops.
+            env["AGENTIC_DISABLE_AUTOLOAD"]    = "1"
+
+        popen_kwargs = {
+            "stdin"  : subprocess.DEVNULL,
+            "stdout" : subprocess.DEVNULL,
+            "stderr" : subprocess.PIPE,
+            "env"    : env,
+        }
+        if sys.platform.startswith("linux"):
+            popen_kwargs["preexec_fn"] = _die_with_parent
+
+        proc = subprocess.Popen(cmd, **popen_kwargs)
         # Why stdin=DEVNULL: when this MCP server is launched via stdio
         # (Claude Code's default), our own stdin is the JSON-RPC socket.
         # If the worker inherits that fd, renderdoc/renderdoccmd may read
@@ -619,10 +687,32 @@ class RenderDocClient:
             self._reap_proc(proc)
             err_bytes = b"".join(stderr_buffer)
             err_text  = err_bytes.decode("utf-8", errors="replace").strip()
+
+            # Embedded-headless mode (qrenderdoc --script) doesn't write
+            # diagnostics to stderr — qrenderdoc is a GUI subprocess. Read
+            # the per-port log file the script writes instead. The path
+            # must match the one embedded_headless.py writes.
+            log_text = ""
+            if windows_embedded:
+                base = os.environ.get("TEMP") or os.environ.get("TMP") or "."
+                log_path = os.path.join(
+                    base, f"agentic-renderdoc-embedded-{bridge_port}.log"
+                )
+                try:
+                    with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+                        log_text = f.read().strip()
+                except OSError:
+                    pass
+
+            if windows_embedded:
+                diag  = log_text or err_text or "<empty>"
+                label = "embedded-log"
+            else:
+                diag  = err_text or "<empty>"
+                label = "stderr"
             raise RuntimeError(
                 f"headless worker did not bind on {bridge_port} within "
-                f"{_WORKER_BIND_WAIT:.0f}s; stderr: "
-                f"{err_text or '<empty>'}"
+                f"{_WORKER_BIND_WAIT:.0f}s; {label}: {diag}"
             )
 
         # Worker is healthy. Stop buffering — drain thread keeps reading


### PR DESCRIPTION
The README lists Windows as a supported platform, but in practice the extension fails to load inside qrenderdoc.exe's embedded Python on Windows (verified on RenderDoc 1.44), and the headless worker spawned by ``Instance.open`` can't import the SWIG bindings because they aren't shipped as a standalone module on Windows.

Verified end-to-end: live mode (manual qrenderdoc + ``Instance.list``
+ ``Eval``) and headless mode (``Instance.open`` + ``Eval`` + ``Instance.close``) now both work on Windows. Linux Python 3.10+ behaviour is unchanged.

## Root causes

1. Every ``src/extension/*.py`` file uses ``from __future__ import annotations`` and PEP-604 / PEP-585 type-hint syntax. qrenderdoc embeds Python 3.6.4, which doesn't accept any of those. The extension's ``register()`` is never reached because the package fails to import. ``AlwaysLoad_Extensions`` silently swallows the failure.

2. qrenderdoc's bundled Python 3.6 ships without ``_socket``. ``context.py`` imports ``concurrent.futures`` at module load, which transitively requires ``socket`` via ``multiprocessing`` — so even after the syntax issue is fixed, the GUI extension still fails to load.

3. RenderDoc on Windows doesn't ship a standalone ``renderdoc.pyd`` — the SWIG bindings are statically linked into ``qrenderdoc.exe`` and only reachable from inside its embedded Python. The existing ``extension/headless.py`` path is therefore broken on Windows: it spawns a separate Python worker that can't ``import renderdoc``.

4. qrenderdoc's ``AlwaysLoad_Extensions`` matches the extension directory name (``agentic_renderdoc``, with an underscore) inconsistently with ``extension.json``'s ``name`` (``agentic- renderdoc``, with a hyphen). Listing only the hyphenated form is silently ignored. Workaround documented; not fixable from the extension side.

## Changes

* **Syntax migration across 8 files**. Drop ``from __future__ import annotations``, replace PEP-604 union syntax (``X | None``) and PEP-585 subscripted built-in generics (``list[X]``) with ``typing.Optional``/``typing.List``/etc. ``collections.abc.Callable`` → ``typing.Callable`` in modules that subscript it (the ``collections.abc`` form's ``__class_getitem__`` requires Python 3.9+).

* **Lazy-import ``concurrent.futures`` / ``queue`` inside ``HeadlessHandlerContext.__init__``**. The external-Python headless worker still uses both, but the GUI path no longer pulls them in at module load, so the package imports cleanly inside qrenderdoc's socket-less Python.

* **``SO_REUSEADDR`` on the threaded bridge listener** (``bridge.py:_ThreadedBridge.start``). Cross-platform improvement that prevents the rebind race when the parent's port-discovery probe in ``_first_free_port`` and the worker's ``bind()`` are close in time.

* **New ``EmbeddedHeadlessContext``** in ``context.py``. In-process replay via ``rd.OpenCaptureFile`` / ``OpenCapture`` instead of ``CreateRemoteServerConnection``. Same single-replay-thread discipline as ``HeadlessHandlerContext``, with ``threading.Event`` used for setup signalling instead of ``concurrent.futures.Future`` (since the latter can't be imported at module scope).

* **New ``src/extension/embedded_headless.py``**. Thin entry script (~130 lines) invoked as ``qrenderdoc --script``. Reads env-var config (since qrenderdoc doesn't populate ``sys.argv`` under ``--script``), prepends the package's parent dir to ``sys.path``, opens the capture in-process via ``EmbeddedHeadlessContext``, hosts the existing ``BridgeServer`` with ``force_threaded=True`` and the upstream ``HANDLERS``, blocks on the bridge's ``_running`` flag, then ``os._exit(0)`` so qrenderdoc never reaches its UI step. No logic duplicated from the package — all the reused handlers (``eval``, ``instance_info``, ``shutdown``, etc.) come from ``extension/handlers.py`` so Windows users get the full ``bind_utilities`` eval surface.

* **``AGENTIC_DISABLE_AUTOLOAD`` env var**. Set by the Windows branch of ``spawn_headless_worker`` so the extension's ``register()`` no-ops, preventing qrenderdoc's ``AlwaysLoad_Extensions`` from binding a competing bridge on the same port. Without this, on Windows, ``SO_REUSEADDR`` has hijacking semantics: both bridges bind 19876 as listeners and incoming connections routinely hit the GUI bridge (with ``capture_loaded=false``) instead of ours.

* **Windows branch in ``src/server/client.py:spawn_headless_worker``**. Guarded by ``sys.platform == "win32"``. Launches ``qrenderdoc.exe --script embedded_headless.py`` with env-var config in place of ``python -m extension.headless``. Skips the ``renderdoccmd remote-server`` port allocation since the embedded path doesn't use one. Bind-failure error message reads the ``%TEMP%/agentic-renderdoc-embedded-<port>.log`` file the script writes (qrenderdoc as a GUI subprocess produces no visible stderr). Adds ``_find_qrenderdoc()`` helper that searches PATH then the standard Windows install paths.

* **``docs/WINDOWS_SUPPORT.md``**. Full design write-up covering the three platform constraints, the ``embedded_headless.py`` design, ``AGENTIC_DISABLE_AUTOLOAD`` env var, the ``AlwaysLoad_Extensions`` name-mismatch workaround, and a per-file change summary.

## Linux / macOS

* All replaced annotation syntax (``typing.Optional``, ``typing.List``, etc.) is valid in every Python ≥3.5.
* The lazy-import in ``HeadlessHandlerContext.__init__`` is a timing change only — the same modules are imported, just one frame later.
* The new ``EmbeddedHeadlessContext`` exists on all platforms but is only instantiated by ``embedded_headless.py``, which is only spawned from the Windows branch of ``client.py``.
* ``SO_REUSEADDR`` on the threaded bridge: on Linux/macOS this allows rebind through TIME_WAIT — standard, safe behaviour. On Windows it enables the hijacking case the ``AGENTIC_DISABLE_AUTOLOAD`` env var is paired against.
* ``AGENTIC_DISABLE_AUTOLOAD`` is only set by the Windows branch; Linux/macOS code paths never see it, so ``register()`` runs normally there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)