### PR TITLE
fix: connect-probe in _first_free_port to skip live bridges

### DIFF
--- a/src/server/client.py
+++ b/src/server/client.py
@@ -824,10 +824,24 @@ class RenderDocClient:
     # --- Internal: worker spawn helpers ---
 
     def _first_free_port(self, port_range: range, exclude: set[int] | None = None) -> int | None:
-        """Return the first locally-bindable port in range, skipping exclude."""
+        """Return the first locally-bindable port in range, skipping exclude.
+
+        A bind probe with ``SO_REUSEADDR`` is not enough on Windows: the
+        extension's bridge listener also sets ``SO_REUSEADDR`` (see
+        ``bridge.py:_ThreadedBridge.start``), so two listeners can coexist
+        on the same port. ``bind()`` would silently succeed against a port
+        that already has a running bridge, and the worker we then spawn
+        would race the existing bridge for incoming connections.
+        Connect-probe first to detect a live bridge.
+        """
         excl = exclude or set()
         for port in port_range:
             if port in excl:
+                continue
+            if self._probe_port(port) is not None:
+                # Something is already listening — could be a GUI bridge
+                # on the same port that we'd otherwise hijack via
+                # SO_REUSEADDR.
                 continue
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)


### PR DESCRIPTION
## Summary

`_first_free_port` could return a port that already had a running bridge listener, because the bind probe set `SO_REUSEADDR` and the bridge listener (added in #1) also sets `SO_REUSEADDR` — so on Windows two listeners coexist on the same port and `bind()` silently succeeds against the in-use port. The pool then spawns a worker on top of the existing bridge.

## Repro

With qrenderdoc already hosting the GUI bridge on 19876, run `Instance(action="open", file=...)`. The worker binds 19876 alongside the GUI bridge. Connections to 19876 hit whichever listener the OS gives `accept()` to. The parent's wait-probe lands on the GUI bridge (`capture_loaded=False`) and the open times out at 30s even though the worker is healthy and reporting `bridge bound on localhost:19876` in its embedded log.

## Fix

Add a TCP connect probe ahead of the bind probe — if anything answers, the port is in use regardless of what `bind()` reports. `_probe_port` already exists for `discover_instances`, so it's reused. Cross-platform: on Linux/macOS the bind probe alone already rejects in-use ports, so the extra check is a fast no-op there.

## Test plan

- [x] Verified on Windows with qrenderdoc holding 19876: `Instance(action="open", ...)` now allocates 19877 and the embedded worker binds cleanly. Capture loads (D3D11, 1243 events) and Eval round-trips.
- [x] Verified `Instance(action="close")` returns `exit_code: 0`.
- [ ] Linux regression check (no expected change — the connect probe is a fast no-op when ports are truly free)

🤖 Generated with [Claude Code](https://claude.com/claude-code)